### PR TITLE
Open the redirected link in a new tab

### DIFF
--- a/background.js
+++ b/background.js
@@ -8,7 +8,13 @@ function appendSciHub(tab, link){
 
   console.log('Redirecting ' + tab.url + ' to ' + new_url);
 
-  chrome.tabs.update(tab.id, {url: new_url});
+  chrome.tabs.query({
+      active: true
+    }, tabs => {
+      let index = tabs[0].index;
+      chrome.tabs.create({index: index + 1, url: new_url});
+    }
+  );
 }
 
 // Setup extension click action


### PR DESCRIPTION
Hi @allanino

Regarding issue #2, I just quickly tweaked the code to make it open the redirected link in a new tab (in the foreground) next to the active one.

I think this somehow makes more sense in terms of user experience (e.g. I'm searching papers in Google Scholar, it may be better if the redirected link doesn't overwrite the search page). Feel free to merge if you want. Thanks.

Amazing work! Thanks.
