### PR TITLE
Updating background.js with the Updated Sci-Hub domain

### DIFF
--- a/background.js
+++ b/background.js
@@ -9,7 +9,7 @@ function sciHubFy(link, sciHubDomain) {
 function newTabSciHubFy(tab, link) {
   // Tab is the current tab and link is the link to append sci-hub.io
   chrome.storage.sync.get({
-    domain: 'sci-hub.cc'  // Default domain
+    domain: 'sci-hub.bz // Updated default domain ( As of DEC 03 - 2017 )
   }, function(items) {
     chrome.tabs.query({
         active: true
@@ -24,7 +24,7 @@ function newTabSciHubFy(tab, link) {
 function sameTabSciHubFy(tab, link) {
   // Tab is the current tab and link is the link to append sci-hub.io
   chrome.storage.sync.get({
-    domain: 'sci-hub.cc' // Default domain
+    domain: 'sci-hub.bz' // Updated default domain ( As of DEC 03 - 2017 )
   }, function(items) {
     chrome.tabs.update(tab.id, {url: sciHubFy(link, items.domain)});
   });


### PR DESCRIPTION
The domain which the current version of the extension uses i.e 'sci-hub.cc' has been changed to 'sci-hub.bz' ( As of DEC 03 - 2017 )
So the extension doesn't work.

All this commit does is to change the domain to 'sci-hub.bz' and doing so, works!