### PR TITLE
Updating ReadME.md and background.js with the Updated Sci-Hub domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Sci-Hub-Fy
 ==========
 
-Chrome extension that appends ".sci-hub.cc" to active tab domain, allowing free access to scientific articles.
+Chrome extension that appends ".sci-hub.bz" to active tab domain, allowing free access to scientific articles.
 
 The hard work is done by [Sci-Hub].
 
@@ -22,7 +22,7 @@ You can load it as an unpacked extension in developer mode on Chrome. Follow thi
 
 Another way of using this extension is through the context menu (right-click):
 
-- Link context: if you right-click a link and select Sci-Hub-Fy, we append ".sci-hub.cc" to the link and redirect you to it.
-- Page context: if you right-click anywhere but a link in a page, we append ".sci-hub.cc" to the page's URL and redirect you to it (the same as clicking in the extension icon).
+- Link context: if you right-click a link and select Sci-Hub-Fy, we append ".sci-hub.bz" to the link and redirect you to it.
+- Page context: if you right-click anywhere but a link in a page, we append ".sci-hub.bz" to the page's URL and redirect you to it (the same as clicking in the extension icon).
 
-[Sci-Hub]:http://sci-hub.cc
+[Sci-Hub]:http://sci-hub.bz

--- a/background.js
+++ b/background.js
@@ -9,7 +9,7 @@ function sciHubFy(link, sciHubDomain) {
 function newTabSciHubFy(tab, link) {
   // Tab is the current tab and link is the link to append sci-hub.io
   chrome.storage.sync.get({
-    domain: 'sci-hub.bz // Updated default domain ( As of DEC 03 - 2017 )
+    domain: 'sci-hub.bz' // Updated default domain ( As of DEC 03 - 2017 )
   }, function(items) {
     chrome.tabs.query({
         active: true

--- a/background.js
+++ b/background.js
@@ -9,7 +9,7 @@ function sciHubFy(link, sciHubDomain) {
 function newTabSciHubFy(tab, link) {
   // Tab is the current tab and link is the link to append sci-hub.io
   chrome.storage.sync.get({
-    domain: 'sci-hub.cc'  // Default domain
+    domain: 'sci-hub.bz // Updated default domain ( As of DEC 03 - 2017 )
   }, function(items) {
     chrome.tabs.query({
         active: true
@@ -24,7 +24,7 @@ function newTabSciHubFy(tab, link) {
 function sameTabSciHubFy(tab, link) {
   // Tab is the current tab and link is the link to append sci-hub.io
   chrome.storage.sync.get({
-    domain: 'sci-hub.cc' // Default domain
+    domain: 'sci-hub.bz' // Updated default domain ( As of DEC 03 - 2017 )
   }, function(items) {
     chrome.tabs.update(tab.id, {url: sciHubFy(link, items.domain)});
   });


### PR DESCRIPTION
The domain which the current version of the extension uses i.e 'sci-hub.cc' has been changed to 'sci-hub.bz' ( As of DEC 03 - 2017 )
So the extension doesn't work.

All this commit does is to change the domain to 'sci-hub.bz' and doing so, works!