### PR TITLE
Update URL rewrite logic 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 Sci-Hub-Fy
 ==========
 
-Chrome extension that appends ".sci-hub.tw" to active tab domain, allowing free access to scientific articles.
+Chrome extension that passes URLs to Sci-Hub, allowing free access to scientific articles.
 
 The hard work is done by [Sci-Hub].
 
-**Note:** The extension got removed from Chrome Store as they "don't allow products or services that facilitate unauthorized access to content on websites, such as circumventing paywalls or logins restrictions.". Of course you can just manually append the ".sci-hub.tw", but if you still want to automate this, the instructions below should make it work.
+**Note:** The extension got removed from Chrome Store as they "don't allow products or services that facilitate unauthorized access to content on websites, such as circumventing paywalls or logins restrictions.". Of course you can just manually prepend "http://sci-hub.tw/" to the URL, but if you still want to automate this, the instructions below should make it work.
 
 ## Installation
 
@@ -22,7 +22,7 @@ You can load it as an unpacked extension in developer mode on Chrome. Follow thi
 
 Another way of using this extension is through the context menu (right-click):
 
-- Link context: if you right-click a link and select Sci-Hub-Fy, we append ".sci-hub.tw" to the link and redirect you to it.
-- Page context: if you right-click anywhere but a link in a page, we append ".sci-hub.tw" to the page's URL and redirect you to it (the same as clicking in the extension icon).
+- Link context: if you right-click a link and select Sci-Hub-Fy, we prepend "http://sci-hub.tw/" to the link and redirect you to it.
+- Page context: if you right-click anywhere but a link in a page, we prepend "http://sci-hub.tw/" to the page's URL and redirect you to it (the same as clicking in the extension icon).
 
 [Sci-Hub]:http://sci-hub.tw

--- a/background.js
+++ b/background.js
@@ -1,9 +1,8 @@
 // Copyright (c) 2014 Allan Costa.
 
 function sciHubFy(link, sciHubDomain) {
-  // Append Sci-Hub domain to link's domain
-  var matches = link.match(/:\/\/(?:www\.)?(.[^/]+)(.*)/);
-  return "http://" + matches[1] + "." + sciHubDomain + matches[2];
+  // Use the link to search on Sci-Hub
+  return "http://" + sciHubDomain + '/' + link;
 }
 
 function newTabSciHubFy(tab, link) {

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Sci-Hub-Fy",
   "description": "Free access to scientific articles through Sci-Hub service.",
-  "version": "1.6",
+  "version": "1.6.1",
 
   "permissions": [
      "activeTab",


### PR DESCRIPTION
The original logic no longer works. Take https://ieeexplore.ieee.org/document/5368126 as an example. The rewritten URL http://ieeexplore.ieee.org.sci-hub.tw/document/5368126 now redirects to itself.