### PR TITLE
Fix: Change references to most recent domain .st

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Chrome extension that passes URLs to Sci-Hub, allowing free access to scientific
 
 The hard work is done by [Sci-Hub].
 
-**Note:** The extension got removed from Chrome Store as they "don't allow products or services that facilitate unauthorized access to content on websites, such as circumventing paywalls or logins restrictions.". Of course you can just manually prepend "http://sci-hub.tw/" to the URL, but if you still want to automate this, the instructions below should make it work.
+**Note:** The extension got removed from Chrome Store as they "don't allow products or services that facilitate unauthorized access to content on websites, such as circumventing paywalls or logins restrictions.". Of course you can just manually prepend "http://sci-hub.st/" to the URL, but if you still want to automate this, the instructions below should make it work.
 
 ## Installation
 
@@ -22,7 +22,7 @@ You can load it as an unpacked extension in developer mode on Chrome. Follow thi
 
 Another way of using this extension is through the context menu (right-click):
 
-- Link context: if you right-click a link and select Sci-Hub-Fy, we prepend "http://sci-hub.tw/" to the link and redirect you to it.
-- Page context: if you right-click anywhere but a link in a page, we prepend "http://sci-hub.tw/" to the page's URL and redirect you to it (the same as clicking in the extension icon).
+- Link context: if you right-click a link and select Sci-Hub-Fy, we prepend "http://sci-hub.st/" to the link and redirect you to it.
+- Page context: if you right-click anywhere but a link in a page, we prepend "http://sci-hub.st/" to the page's URL and redirect you to it (the same as clicking in the extension icon).
 
-[Sci-Hub]:http://sci-hub.tw
+[Sci-Hub]:http://sci-hub.st

--- a/background.js
+++ b/background.js
@@ -8,7 +8,7 @@ function sciHubFy(link, sciHubDomain) {
 function newTabSciHubFy(tab, link) {
   // Tab is the current tab and link is the link to append sci-hub.io
   chrome.storage.sync.get({
-    domain: 'sci-hub.tw' // Updated default domain ( As of DEC 03 - 2017 )
+    domain: 'sci-hub.st' // Updated default domain ( As of DEC 03 - 2017 )
   }, function(items) {
     chrome.tabs.query({
         active: true
@@ -23,7 +23,7 @@ function newTabSciHubFy(tab, link) {
 function sameTabSciHubFy(tab, link) {
   // Tab is the current tab and link is the link to append sci-hub.io
   chrome.storage.sync.get({
-    domain: 'sci-hub.tw' // Updated default domain ( As of DEC 03 - 2017 )
+    domain: 'sci-hub.st' // Updated default domain ( As of DEC 03 - 2017 )
   }, function(items) {
     chrome.tabs.update(tab.id, {url: sciHubFy(link, items.domain)});
   });

--- a/options.html
+++ b/options.html
@@ -9,8 +9,8 @@
   <body>
     <form>
       <h1>Set your Domain <br> for Sci-Hub Services</h1>
-      <input placeholder="Domain (e.g. sci-hub.tw)" type="text" required="" id="domain">
-      <p class="label">Domain (e.g. sci-hub.tw)</p>
+      <input placeholder="Domain (e.g. sci-hub.st)" type="text" required="" id="domain">
+      <p class="label">Domain (e.g. sci-hub.st)</p>
       <button class="ripple" id="save">Save</button>
     </form>
 

--- a/options.js
+++ b/options.js
@@ -7,9 +7,9 @@ function save_options() {
 // Restores select box and checkbox state using the preferences
 // stored in chrome.storage.
 function restore_options() {
-  // Use default value domain = 'sci-hub.tw'
+  // Use default value domain = 'sci-hub.st'
   chrome.storage.sync.get({
-    domain: 'sci-hub.tw'
+    domain: 'sci-hub.st'
   }, function(items) {
     document.getElementById('domain').value = items.domain;
   });


### PR DESCRIPTION
This patch updates the Sci-hub URL to the most recent domain (sci-hub.st)